### PR TITLE
todo.txt view plugin fix

### DIFF
--- a/view
+++ b/view
@@ -56,7 +56,7 @@ function project_view() {
     # For each project show header and the list of todo items
     for project in $PROJECTS; do
         # Use core _list function, does numbering and colouring for us
-        PROJECT_LIST=$(_list "$TODO_FILE" "+$project" "$term" | sed 's/\(^+\|\ *+\)[a-zA-Z0-9\{._\-\}]*\ */ /g')
+        PROJECT_LIST=$(_list "$TODO_FILE" "+$project\b" "$term" | sed 's/\(^+\|\ *+\)[a-zA-Z0-9\{._\-\}]*\ */ /g')
         if [[ -n "${PROJECT_LIST}" ]]; then
             echo "---  $project  ---"
             echo "${PROJECT_LIST}"
@@ -83,7 +83,7 @@ function context_view() {
     # For each context show header and the list of todo items
     for context in $CONTEXTS ; do
         # Use core _list function, does numbering and colouring for us
-        CONTEXT_LIST=$(_list "$TODO_FILE" "@$context" "$term" | sed 's/\(^@\|\ *@\)[^ ]*\ */ /g')
+        CONTEXT_LIST=$(_list "$TODO_FILE" "@$context\b" "$term" | sed 's/\(^@\|\ *@\)[^ ]*\ */ /g')
         if [[ -n "${CONTEXT_LIST}" ]]; then
             echo "---  $context  ---"
             echo "${CONTEXT_LIST}"


### PR DESCRIPTION
Hey Mark,

Glad to see my projectview plugin is useful as a jumping off point. 

I fixed a long standing issue with it over the weekend. Essentially a project of +test1 will be shown with +test projects without the \b word boundary addition, the search now looks for +test with a space, tab or newline after it. This tests okay on my setup, but I'm not able to test on all versions of grep (Mac standard version is very old)

Thanks for using my initial work and improving.

Regards,
Paul Mansfield
