### PR TITLE
Color Leakage fix by madeddie

### DIFF
--- a/view
+++ b/view
@@ -83,7 +83,7 @@ function context_view() {
     # For each context show header and the list of todo items
     for context in $CONTEXTS ; do
         # Use core _list function, does numbering and colouring for us
-        CONTEXT_LIST=$(_list "$TODO_FILE" "@$context\b" "$term" | sed 's/\(^@\|\ *@\)[^ ]*\ */ /g')
+        CONTEXT_LIST=$(_list "$TODO_FILE" "@$context\b" "$term" | sed 's/(^@|\ *@)[^[:cntrl:] ]\ */ /g')
         if [[ -n "${CONTEXT_LIST}" ]]; then
             echo "---  $context  ---"
             echo "${CONTEXT_LIST}"


### PR DESCRIPTION
Issue reported by madeddie:

"I noticed color codes not being properly reset at the end of the line of some tasks in the context view. This is caused by the last '' in sed 's/(^@|\ *@)[^ ]\ / /g'
Changing it to sed 's/(^@|\ *@)[^[:cntrl:] ]\ */ /g' solves the problem."

The change is on line 11 in the context_view() function.
