### PR TITLE
More flexible argument parsing, enables shortcuts for project/context

### DIFF
--- a/view
+++ b/view
@@ -190,29 +190,32 @@ function date_check() {
     return 0
 }
 
+function error() {
+    [[ -z $option ]] || echo "Error: Unrecognized option \"$option\"."
+    usage
+}
+
 # Validate the input options
-re="^(help|project|context|date|nodate|future|past|today|tomorrow|yesterday|([+-][0-9]+|[0-9]+)(days|weeks|months|years))$"
-if [[ "$option" =~ $re ]]; then
-    case $option in
-    'help')
+case $option in
+    'help'|'usage'|'-h'|'')
         usage
         ;;
-    'project')
+    'project'|'+')
         project_view
         ;;
-    'context')
+    'context'|'@')
         context_view
         ;;
     *)
         re="^(date|nodate|future|past)$"
         if [[ ! ( "$option" =~ $re ) ]]; then
-            option=$(date -d $(date -d $option +%Y-%m-%d) +%s)
+            date=$(date -d "$option" +%Y-%m-%d 2>/dev/null)
+            [[ $? != 0 ]] && error
+            date=$(date -d $date +%s 2>/dev/null)
+        else
+            date="$option"
         fi
 
-        date_view $option
+        date_view $date
         ;;
-    esac
-else
-    echo "Error: Unrecognized option \"$option\"."
-    echo "Try \"todo.sh view help\" to get more information."
-fi
+esac


### PR DESCRIPTION
Rather than validating against a regular expression, any argument not directly matched by the set of cases is passed to the `date` command and attempted to be evaluated as a date. If `date` fails to parse the argument, it is assumed to be an unrecognised option.

This change also makes adding new options to the case set easier, so I added shortcut versions of the project and context view modes: + and @ respectively. This change was actually the reason I made the other changes, supporting more sorts of dates being just a nice side-effect. These shortcuts are provided for the same reason `view` is aliased as `v`: to save typing.

```
$ todo.sh view project
$ t v +
# compare and contrast ;)
```
