### PR TITLE
Ignore case when getting contexts

### DIFF
--- a/view
+++ b/view
@@ -78,7 +78,7 @@ function context_view() {
     echo ""
 
     # Find all contexts and sort
-    CONTEXTS=$(grep -o '[^  ]*@[^  ]\+' "$TODO_FILE" | grep '^@' | sort -u | sed 's/@//g')
+    CONTEXTS=$(grep -o '[^  ]*@[^  ]\+' "$TODO_FILE" | grep '^@' | sort -uf | sed 's/@//g')
 
     # For each context show header and the list of todo items
     for context in $CONTEXTS ; do


### PR DESCRIPTION
Currently if you have some tasks under a context @Github and some under @github, you'll have a duplicate list of tasks.
Flag `-f` ignores case when sorting, so the list is unique now.
